### PR TITLE
EnkaAPI // + EachAvatarStatView, etc.

### DIFF
--- a/Packages/HBEnkaAPI/Package.swift
+++ b/Packages/HBEnkaAPI/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "HBEnkaAPI",
-            targets: ["HBEnkaAPI"]
+            targets: ["HBEnkaAPI", "EnkaSwiftUIViews"]
         ),
     ],
     dependencies: [

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -18,7 +18,7 @@ public struct EachAvatarStatView: View {
     public var body: some View {
         VStack(spacing: 6) {
             data.mainInfo
-            VStack {
+            VStack(spacing: 2) {
                 data.equippedWeapon
                 VStack(spacing: 0) {
                     ForEach(data.avatarProperties, id: \.type) { property in
@@ -217,19 +217,19 @@ extension EnkaHSR.AvatarSummarized.WeaponPanel: View {
                 verbatim: "Lv.\(trainedLevel) ★\(rarityStars)",
                 alignment: .bottom, textSize: baseFontSize * 0.8
             )
-            VStack(alignment: .leading, spacing: 1) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(localizedName)
                     .fontWeight(.bold)
                     .fontWidth(.condensed)
                 Divider().overlay {
                     Color.primary.opacity(0.6)
-                }
+                }.padding(.vertical, 2)
                 ForEach(props, id: \.type) { propUnit in
                     AttributeTagPair(
                         icon: propUnit.iconFilePath,
                         title: propUnit.localizedTitle,
                         valueStr: propUnit.valueString,
-                        fontSize: baseFontSize * 0.93,
+                        fontSize: baseFontSize * 0.9,
                         dash: false
                     )
                 }

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -381,7 +381,7 @@ struct EachAvatarStatView_Previews: PreviewProvider {
             separator: "/"
         ).dropFirst()
         let testDataPath: String = packageRootPath + "/Tests/TestData/"
-        let filePath = testDataPath + "TestQueryResult.json"
+        let filePath = testDataPath + "TestQueryResultEnka.json"
         let dataURL = URL(fileURLWithPath: filePath)
         let profile = try! Data(contentsOf: dataURL).parseAs(EnkaHSR.QueryRelated.QueriedProfile.self)
         let summary = profile.detailInfo!.avatarDetailList[3].summarize(theDB: enkaDatabase)!

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -3,3 +3,391 @@
 // This code is released under the GPL v3.0 License (SPDX-License-Identifier: GPL-3.0)
 
 import Foundation
+import HBEnkaAPI
+import SwiftUI
+
+private let baseFontSize: CGFloat = 16
+
+// MARK: - EachAvatarStatView
+
+public struct EachAvatarStatView: View {
+    // MARK: Public
+
+    public let data: EnkaHSR.AvatarSummarized
+
+    public var body: some View {
+        VStack(spacing: 6) {
+            data.mainInfo
+            VStack {
+                data.equippedWeapon
+                VStack(spacing: 0) {
+                    ForEach(data.avatarProperties, id: \.type) { property in
+                        AttributeTagPair(
+                            icon: property.type.iconFilePath,
+                            title: property.localizedTitle,
+                            valueStr: property.valueString
+                        )
+                    }
+                }
+            }
+            .padding(.horizontal, 11)
+            .padding(.vertical, 6)
+            .background {
+                Color.black.opacity(0.2)
+                    .clipShape(.rect(cornerSize: .init(width: 12, height: 12)))
+            }
+            artifactsList
+            Spacer()
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .preferredColorScheme(.dark)
+        .background {
+            AsyncImage(url: URL(fileURLWithPath: data.mainInfo.photoFilePath)) { imageObj in
+                imageObj
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .blur(radius: 60)
+                    .contrast(2)
+                    .opacity(0.47)
+            } placeholder: {
+                Color.clear
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private var artifactsList: some View {
+        StaggeredGrid(columns: 2, spacing: 4, list: data.artifacts) { currentArtifact in
+            currentArtifact
+        }
+    }
+}
+
+extension EnkaHSR.AvatarSummarized {
+    public func asView() -> EachAvatarStatView {
+        .init(data: self)
+    }
+}
+
+// MARK: - EnkaHSR.AvatarSummarized.AvatarMainInfo + View
+
+extension EnkaHSR.AvatarSummarized.AvatarMainInfo: View {
+    public var body: some View {
+        HStack {
+            AsyncImage(url: URL(fileURLWithPath: avatarFilePath)) { imageObj in
+                imageObj
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .background {
+                        Color.black.opacity(0.165)
+                    }
+            } placeholder: {
+                Color.clear
+            }
+            .frame(maxWidth: 96, maxHeight: 86)
+            .clipShape(Circle())
+            VStack(spacing: 0) {
+                HStack {
+                    Text(localizedName)
+                        .font(.system(size: 30))
+                        .fontWeight(.bold)
+                        .lineLimit(1).fixedSize()
+                        .minimumScaleFactor(0.5)
+                    Spacer()
+
+                    ZStack(alignment: .center) {
+                        Color.black.opacity(0.1)
+                            .clipShape(Circle())
+                        AsyncImage(url: URL(fileURLWithPath: lifePath.iconFilePath)) { imageObj in
+                            imageObj.resizable().aspectRatio(contentMode: .fit)
+                        } placeholder: {
+                            Color.clear
+                        }
+                        .clipShape(Circle())
+                    }.frame(
+                        width: baseFontSize * 2.6,
+                        height: baseFontSize * 2
+                    ).overlay(alignment: .bottomTrailing) {
+                        ZStack(alignment: .center) {
+                            Color.black.opacity(0.05)
+                                .clipShape(Circle())
+                            AsyncImage(url: URL(fileURLWithPath: element.iconFilePath)) { imageObj in
+                                imageObj
+                                    .resizable()
+                                    .brightness(0.1)
+                            } placeholder: {
+                                Color.clear
+                            }
+                            .clipShape(Circle())
+                        }.frame(
+                            width: 18,
+                            height: 18
+                        )
+                        .background {
+                            Color.black.clipShape(Circle()).blurMaterialBackground().opacity(0.3)
+                        }
+                    }
+                }
+                .shadow(radius: 5)
+                HStack(spacing: 0) {
+                    VStack(spacing: 4) {
+                        AttributeTagPair(
+                            title: "等级", valueStr: self.avatarLevel.description,
+                            fontSize: baseFontSize * 0.9, dash: false
+                        )
+                        AttributeTagPair(
+                            title: "命之座", valueStr: "C\(self.constellation)",
+                            fontSize: baseFontSize * 0.9, dash: false
+                        )
+                    }.frame(maxWidth: 100, maxHeight: .infinity)
+                        .shadow(radius: /*@START_MENU_TOKEN@*/10/*@END_MENU_TOKEN@*/)
+                    HStack(alignment: .lastTextBaseline, spacing: 0) {
+                        ForEach(baseSkills.toArray, id: \.type) { skill in
+                            skill.fixedSize()
+                        }
+                    }
+                    .minimumScaleFactor(0.5)
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+// MARK: - EnkaHSR.AvatarSummarized.AvatarMainInfo.BaseSkillSet.BaseSkill + View
+
+extension EnkaHSR.AvatarSummarized.AvatarMainInfo.BaseSkillSet.BaseSkill: View {
+    func levelDisplay(size: CGFloat) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            Text("\(self.adjustedLevel)").font(.system(size: size * 0.93, weight: .heavy))
+        }
+    }
+
+    public var body: some View {
+        ZStack(alignment: .bottom) {
+            VStack {
+                ZStack(alignment: .center) {
+                    Color.black.opacity(0.1)
+                        .clipShape(Circle())
+                    AsyncImage(url: URL(fileURLWithPath: iconFilePath)) { imageObj in
+                        imageObj.resizable()
+                    } placeholder: {
+                        Color.clear
+                    }
+                    .clipShape(Circle())
+                    .scaleEffect(0.8)
+                }.frame(
+                    width: baseFontSize * 2.6,
+                    height: baseFontSize * 2.6
+                )
+                Spacer()
+            }
+            // 这里不用 corneredTag，因为要动态调整图示与等级数字之间的显示距离。
+            // 而且 skill.levelDisplay 也不是纯文本，而是 some View。
+            ZStack(alignment: .center) {
+                Color.black.opacity(0.1)
+                    .clipShape(Capsule())
+                levelDisplay(size: baseFontSize * 0.9)
+                    .padding(.horizontal, 4)
+            }.frame(height: baseFontSize).fixedSize()
+        }
+    }
+}
+
+// MARK: - EnkaHSR.AvatarSummarized.WeaponPanel + View
+
+extension EnkaHSR.AvatarSummarized.WeaponPanel: View {
+    public var body: some View {
+        HStack(spacing: 14) {
+            AsyncImage(url: URL(fileURLWithPath: iconFilePath)) { imageObj in
+                imageObj
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .background {
+                        Color.primary.opacity(0.075)
+                            .clipShape(Circle())
+                    }
+            } placeholder: {
+                Color.clear
+            }
+            .frame(maxWidth: 80)
+            .corneredTag(
+                verbatim: "Lv.\(trainedLevel) ★\(rarityStars)",
+                alignment: .bottom, textSize: baseFontSize * 0.8
+            )
+            VStack(alignment: .leading, spacing: 1) {
+                Text(localizedName)
+                    .fontWeight(.bold)
+                    .fontWidth(.condensed)
+                Divider().overlay {
+                    Color.primary.opacity(0.6)
+                }
+                ForEach(props, id: \.type) { propUnit in
+                    AttributeTagPair(
+                        icon: propUnit.iconFilePath,
+                        title: propUnit.localizedTitle,
+                        valueStr: propUnit.valueString,
+                        fontSize: baseFontSize * 0.93,
+                        dash: false
+                    )
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+// MARK: - EnkaHSR.AvatarSummarized.ArtifactInfo + View
+
+extension EnkaHSR.AvatarSummarized.ArtifactInfo: View {
+    public var body: some View {
+        coreBody.padding(.vertical, 2).padding(.leading, 2)
+            .background {
+                Color.black.opacity(0.2)
+                    .clipShape(.rect(cornerSize: .init(width: 12, height: 12)))
+            }
+    }
+
+    public var coreBody: some View {
+        HStack {
+            Color.clear.frame(width: 38)
+            VStack(spacing: 0) {
+                AttributeTagPair(
+                    icon: mainProp.iconFilePath,
+                    title: "",
+                    valueStr: mainProp.valueString,
+                    fontSize: 13,
+                    dash: false
+                )
+                Divider().overlay(.primary)
+                StaggeredGrid(columns: 2, spacing: 0, list: self.subProps) { prop in
+                    HStack(spacing: 0) {
+                        if let iconPath = prop.iconFilePath {
+                            AsyncImage(url: URL(fileURLWithPath: iconPath)) { imageObj in
+                                imageObj
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 20, height: 20)
+                            } placeholder: {
+                                Color.clear
+                            }
+                        }
+                        Text(prop.valueString)
+                            .lineLimit(1)
+                            .font(.system(size: 13))
+                            .fontWidth(.compressed)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                            .minimumScaleFactor(0.5)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .shadow(radius: 10)
+        .corneredTag(
+            verbatim: "Lv.\(trainedLevel) ★\(rarityStars)",
+            alignment: .bottomLeading, textSize: baseFontSize * 0.7
+        )
+        .background(alignment: .topLeading) {
+            AsyncImage(url: URL(fileURLWithPath: iconFilePath)) { imageObj in
+                imageObj
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .opacity(0.9)
+                    .scaleEffect(0.8, anchor: .topLeading)
+            } placeholder: {
+                Color.clear
+            }
+        }
+    }
+}
+
+// MARK: - AttributeTagPair
+
+public struct AttributeTagPair: View {
+    // MARK: Lifecycle
+
+    public init(
+        icon iconPath: String? = nil,
+        title: String,
+        valueStr: String,
+        fontSize givenFontSize: CGFloat? = nil,
+        dash withDashLine: Bool = true
+    ) {
+        self.iconPath = iconPath
+        self.title = title
+        self.valueStr = valueStr
+        self.withDashLine = withDashLine
+        self.fontSize = givenFontSize ?? baseFontSize
+    }
+
+    // MARK: Public
+
+    public let iconPath: String?
+    public let title: String
+    public let valueStr: String
+    public let withDashLine: Bool
+    public let fontSize: CGFloat
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            if let iconPath = iconPath {
+                AsyncImage(url: URL(fileURLWithPath: iconPath)) { imageObj in
+                    imageObj.resizable()
+                } placeholder: {
+                    Color.clear.frame(width: fontSize * 1.25, height: fontSize * 1.25)
+                }
+                .frame(width: fontSize * 1.5, height: fontSize * 1.5)
+            }
+            Text(title)
+                .fixedSize()
+                .lineLimit(1)
+            if withDashLine {
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.2))
+                    .frame(height: 1, alignment: .center)
+                    .padding(.horizontal, 4)
+            } else {
+                Spacer().frame(minWidth: 1)
+            }
+            Text(valueStr)
+                .fixedSize()
+                .lineLimit(1)
+                .font(.system(size: fontSize))
+                .fontWidth(.condensed)
+                .fontWeight(.bold)
+                .padding(.horizontal, 5)
+                .background {
+                    Color.secondary.opacity(0.2).clipShape(.capsule)
+                }
+        }.font(.system(size: fontSize))
+            .fontWidth(.condensed)
+            .fontWeight(.regular)
+    }
+}
+
+// MARK: - EachAvatarStatView_Previews
+
+struct EachAvatarStatView_Previews: PreviewProvider {
+    static let summary: EnkaHSR.AvatarSummarized = {
+        // Note: Do not use #Preview. Otherwise, the preview won't be able to access the assets.
+        let enkaDatabase = EnkaHSR.EnkaDB(locTag: "zh-tw")!
+        let packageRootPath = URL(fileURLWithPath: #file).pathComponents.prefix(while: { $0 != "Sources" }).joined(
+            separator: "/"
+        ).dropFirst()
+        let testDataPath: String = packageRootPath + "/Tests/TestData/"
+        let filePath = testDataPath + "TestQueryResult.json"
+        let dataURL = URL(fileURLWithPath: filePath)
+        let profile = try! Data(contentsOf: dataURL).parseAs(EnkaHSR.QueryRelated.QueriedProfile.self)
+        let summary = profile.detailInfo!.avatarDetailList[3].summarize(theDB: enkaDatabase)!
+        EnkaHSR.assetPathRoot = "\(packageRootPath)/../../Assets"
+        return summary
+    }()
+
+    static var previews: some View {
+        summary.asView()
+    }
+}

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -48,7 +48,7 @@ public struct EachAvatarStatView: View {
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .blur(radius: 60)
-                    .contrast(2)
+                    .saturation(3)
                     .opacity(0.47)
             } placeholder: {
                 Color.clear

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -200,7 +200,7 @@ extension EnkaHSR.AvatarSummarized.AvatarMainInfo.BaseSkillSet.BaseSkill: View {
 
 extension EnkaHSR.AvatarSummarized.WeaponPanel: View {
     public var body: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 6) {
             AsyncImage(url: URL(fileURLWithPath: iconFilePath)) { imageObj in
                 imageObj
                     .resizable()

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -373,6 +373,7 @@ public struct AttributeTagPair: View {
 
 struct EachAvatarStatView_Previews: PreviewProvider {
     static let summary: EnkaHSR.AvatarSummarized = {
+        // swiftlint:disable force_try
         // Note: Do not use #Preview. Otherwise, the preview won't be able to access the assets.
         let enkaDatabase = EnkaHSR.EnkaDB(locTag: "zh-tw")!
         let packageRootPath = URL(fileURLWithPath: #file).pathComponents.prefix(while: { $0 != "Sources" }).joined(
@@ -385,6 +386,7 @@ struct EachAvatarStatView_Previews: PreviewProvider {
         let summary = profile.detailInfo!.avatarDetailList[3].summarize(theDB: enkaDatabase)!
         EnkaHSR.assetPathRoot = "\(packageRootPath)/../../Assets"
         return summary
+        // swiftlint:enable force_try
     }()
 
     static var previews: some View {

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -76,7 +76,7 @@ extension EnkaHSR.AvatarSummarized {
 extension EnkaHSR.AvatarSummarized.AvatarMainInfo: View {
     public var body: some View {
         HStack(spacing: 2) {
-            AsyncImage(url: URL(fileURLWithPath: avatarFilePath)) { imageObj in
+            AsyncImage(url: URL(fileURLWithPath: self.photoFilePath)) { imageObj in
                 imageObj
                     .resizable()
                     .aspectRatio(contentMode: .fit)

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -18,18 +18,37 @@ public struct EachAvatarStatView: View {
     public var body: some View {
         VStack(spacing: 6) {
             data.mainInfo
-            VStack(spacing: 2) {
+            VStack(spacing: 4) {
                 data.equippedWeapon
-                VStack(spacing: 0) {
-                    ForEach(data.avatarProperties, id: \.type) { property in
-                        AttributeTagPair(
-                            icon: property.type.iconFilePath,
-                            title: property.localizedTitle,
-                            valueStr: property.valueString,
-                            fontSize: baseFontSize * 0.95
-                        )
+                HStack {
+                    VStack(spacing: 0) {
+                        ForEach(data.avatarPropertiesA, id: \.type) { property in
+                            AttributeTagPair(
+                                icon: property.type.iconFilePath,
+                                title: property.localizedTitle,
+                                valueStr: property.valueString,
+                                fontSize: baseFontSize * 0.8,
+                                dash: false
+                            )
+                        }
+                    }.fixedSize(horizontal: true, vertical: true)
+                    Divider().overlay {
+                        Color.primary.opacity(0.1)
                     }
+                    VStack(spacing: 0) {
+                        ForEach(data.avatarPropertiesB, id: \.type) { property in
+                            AttributeTagPair(
+                                icon: property.type.iconFilePath,
+                                title: property.localizedTitle,
+                                valueStr: property.valueString,
+                                fontSize: baseFontSize * 0.8,
+                                dash: false
+                            )
+                        }
+                    }.fixedSize(horizontal: false, vertical: true)
                 }
+                .fixedSize(horizontal: false, vertical: true)
+                .minimumScaleFactor(0.5)
             }
             .padding(.horizontal, 11)
             .padding(.vertical, 6)
@@ -42,6 +61,7 @@ public struct EachAvatarStatView: View {
         }
         .fixedSize(horizontal: true, vertical: false)
         .preferredColorScheme(.dark)
+        .padding(.horizontal, 24)
         .background {
             AsyncImage(url: URL(fileURLWithPath: data.mainInfo.photoFilePath)) { imageObj in
                 imageObj
@@ -224,14 +244,27 @@ extension EnkaHSR.AvatarSummarized.WeaponPanel: View {
                 Divider().overlay {
                     Color.primary.opacity(0.6)
                 }.padding(.vertical, 2)
-                ForEach(props, id: \.type) { propUnit in
-                    AttributeTagPair(
-                        icon: propUnit.iconFilePath,
-                        title: propUnit.localizedTitle,
-                        valueStr: propUnit.valueString,
-                        fontSize: baseFontSize * 0.9,
-                        dash: false
-                    )
+                HStack {
+                    ForEach(basicProps, id: \.type) { propUnit in
+                        AttributeTagPair(
+                            icon: propUnit.iconFilePath,
+                            title: "",
+                            valueStr: "+\(propUnit.valueString)",
+                            fontSize: baseFontSize * 0.8,
+                            dash: false
+                        ).fixedSize()
+                    }
+                }
+                HStack {
+                    ForEach(specialProps, id: \.type) { propUnit in
+                        AttributeTagPair(
+                            icon: propUnit.iconFilePath,
+                            title: "",
+                            valueStr: "+\(propUnit.valueString)",
+                            fontSize: baseFontSize * 0.8,
+                            dash: false
+                        )
+                    }.fixedSize()
                 }
             }
         }
@@ -384,7 +417,7 @@ struct EachAvatarStatView_Previews: PreviewProvider {
         let filePath = testDataPath + "TestQueryResultEnka.json"
         let dataURL = URL(fileURLWithPath: filePath)
         let profile = try! Data(contentsOf: dataURL).parseAs(EnkaHSR.QueryRelated.QueriedProfile.self)
-        let summary = profile.detailInfo!.avatarDetailList[3].summarize(theDB: enkaDatabase)!
+        let summary = profile.detailInfo!.avatarDetailList[0].summarize(theDB: enkaDatabase)!
         EnkaHSR.assetPathRoot = "\(packageRootPath)/../../Assets"
         return summary
         // swiftlint:enable force_try

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -25,7 +25,8 @@ public struct EachAvatarStatView: View {
                         AttributeTagPair(
                             icon: property.type.iconFilePath,
                             title: property.localizedTitle,
-                            valueStr: property.valueString
+                            valueStr: property.valueString,
+                            fontSize: baseFontSize * 0.95
                         )
                     }
                 }

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -74,7 +74,7 @@ extension EnkaHSR.AvatarSummarized {
 
 extension EnkaHSR.AvatarSummarized.AvatarMainInfo: View {
     public var body: some View {
-        HStack {
+        HStack(spacing: 2) {
             AsyncImage(url: URL(fileURLWithPath: avatarFilePath)) { imageObj in
                 imageObj
                     .resizable()
@@ -130,7 +130,7 @@ extension EnkaHSR.AvatarSummarized.AvatarMainInfo: View {
                     }
                 }
                 .shadow(radius: 5)
-                HStack(spacing: 0) {
+                HStack {
                     VStack(spacing: 4) {
                         AttributeTagPair(
                             title: "等级", valueStr: self.avatarLevel.description,
@@ -140,7 +140,7 @@ extension EnkaHSR.AvatarSummarized.AvatarMainInfo: View {
                             title: "命之座", valueStr: "C\(self.constellation)",
                             fontSize: baseFontSize * 0.9, dash: false
                         )
-                    }.frame(maxWidth: 100, maxHeight: .infinity)
+                    }.frame(maxWidth: 120, maxHeight: .infinity)
                         .shadow(radius: /*@START_MENU_TOKEN@*/10/*@END_MENU_TOKEN@*/)
                     HStack(alignment: .lastTextBaseline, spacing: 0) {
                         ForEach(baseSkills.toArray, id: \.type) { skill in
@@ -178,8 +178,8 @@ extension EnkaHSR.AvatarSummarized.AvatarMainInfo.BaseSkillSet.BaseSkill: View {
                     .clipShape(Circle())
                     .scaleEffect(0.8)
                 }.frame(
-                    width: baseFontSize * 2.6,
-                    height: baseFontSize * 2.6
+                    width: baseFontSize * 2.2,
+                    height: baseFontSize * 2.2
                 )
                 Spacer()
             }

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/SwiftUIImpl/StaggeredGrid.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/SwiftUIImpl/StaggeredGrid.swift
@@ -1,0 +1,103 @@
+//  StaggeredGrid.swift
+//  StaggeredGrid (iOS)
+//
+//  Created by 李宇鸿 on 2022/8/13.
+//  ref: https://blog.csdn.net/qq_42816425/article/details/126325803
+
+import SwiftUI
+
+// MARK: - StaggeredGrid
+
+// 自定义视图构建器…… Content 外界传递的视图
+
+// T -> 是用来保存可识别的数据集合… 外界传递的列表模型数据
+
+public struct StaggeredGrid<Content: View, T: Identifiable>: View where T: Hashable {
+    // MARK: Lifecycle
+
+    // 提供构造函数的闭包
+    public init(
+        columns: Int,
+        showsIndicators: Bool = false,
+        outerPadding: Bool = true,
+        scroll: Bool = true,
+        spacing: CGFloat = 10,
+        list: [T],
+        @ViewBuilder content: @escaping (T) -> Content
+    ) {
+        self.content = content
+        self.list = list
+        self.outerPadding = outerPadding
+        self.spacing = spacing
+        self.scroll = scroll
+        self.showsIndicators = showsIndicators
+        self.columns = columns
+    }
+
+    // MARK: Public
+
+    // 它将从集合中返回每个对象来构建视图…
+    public var content: (T) -> Content
+
+    public var list: [T]
+
+    // 列……
+    public var columns: Int
+
+    // 属性
+    public var showsIndicators: Bool
+    public var spacing: CGFloat
+
+    public var body: some View {
+        if scroll {
+            ScrollView(.vertical, showsIndicators: showsIndicators) {
+                innerContent
+            }
+        } else {
+            innerContent
+        }
+    }
+
+    // 交错网格功能…
+    public func setUpList() -> [[T]] {
+        // 创建列的空子数组计数…
+        var gridArray: [[T]] = Array(repeating: [], count: columns)
+
+        // 用于Vstack导向视图的拆分数组…
+        var currentIndex = 0
+        for object in list {
+            gridArray[currentIndex].append(object)
+            // increasing index count
+            // and resetting fi overbounds the columns count...
+            // 增加索引计数
+            // 和重置fi越界列计数…
+            if currentIndex == (columns - 1) {
+                currentIndex = 0
+            } else {
+                currentIndex += 1
+            }
+        }
+        return gridArray
+    }
+
+    // MARK: Internal
+
+    @State  var outerPadding: Bool
+
+    @State  var scroll: Bool
+
+    @ViewBuilder  var innerContent: some View {
+        HStack(alignment: .top) {
+            ForEach(setUpList(), id: \.self) { columnsData in
+
+                // 优化使用LazyStack…
+                LazyVStack(spacing: spacing) {
+                    ForEach(columnsData) { object in
+                        content(object)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, outerPadding ? spacing : 0)
+    }
+}

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/SwiftUIImpl/SwiftUIImpl_Pizza.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/SwiftUIImpl/SwiftUIImpl_Pizza.swift
@@ -1,0 +1,115 @@
+// (c) 2023 and onwards Pizza Studio (GPL v3.0 License).
+// ====================
+// This code is released under the GPL v3.0 License (SPDX-License-Identifier: GPL-3.0)
+
+import Foundation
+import SwiftUI
+
+// MARK: - Trailing Text Label
+
+extension View {
+    public func corneredTag(
+        _ stringKey: LocalizedStringKey,
+        alignment: Alignment,
+        textSize: CGFloat = 12,
+        opacity: CGFloat = 1,
+        enabled: Bool = true,
+        padding: CGFloat = 0
+    )
+        -> some View {
+        guard stringKey != "", enabled else { return AnyView(self) }
+        return AnyView(
+            ZStack(alignment: alignment) {
+                self
+                Text(stringKey)
+                    .font(.system(size: textSize))
+                    .fontWidth(.condensed)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 0.3 * textSize)
+                    .adjustedBlurMaterialBackground().clipShape(Capsule())
+                    .opacity(opacity)
+                    .padding(padding)
+                    .fixedSize()
+            }
+        )
+    }
+
+    public func corneredTag(
+        verbatim stringVerbatim: String,
+        alignment: Alignment,
+        textSize: CGFloat = 12,
+        opacity: CGFloat = 1,
+        enabled: Bool = true,
+        padding: CGFloat = 0
+    )
+        -> some View {
+        guard stringVerbatim != "", enabled else { return AnyView(self) }
+        return AnyView(
+            ZStack(alignment: alignment) {
+                self
+                Text(stringVerbatim)
+                    .font(.system(size: textSize))
+                    .fontWidth(.condensed)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 0.3 * textSize)
+                    .adjustedBlurMaterialBackground().clipShape(Capsule())
+                    .opacity(opacity)
+                    .padding(padding)
+                    .fixedSize()
+            }
+        )
+    }
+}
+
+// MARK: - Blur Background
+
+extension View {
+    func blurMaterialBackground() -> some View {
+        modifier(BlurMaterialBackground())
+    }
+
+    func adjustedBlurMaterialBackground() -> some View {
+        modifier(AdjustedBlurMaterialBackground())
+    }
+}
+
+// MARK: - BlurMaterialBackground
+
+struct BlurMaterialBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content.background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+        )
+        .contentShape(RoundedRectangle(
+            cornerRadius: 20,
+            style: .continuous
+        ))
+    }
+}
+
+// MARK: - AdjustedBlurMaterialBackground
+
+struct AdjustedBlurMaterialBackground: ViewModifier {
+    @Environment(\.colorScheme) var colorScheme
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        Group {
+            if colorScheme == .dark {
+                content.background(
+                    .thinMaterial,
+                    in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+                )
+            } else {
+                content.background(
+                    .regularMaterial,
+                    in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+                )
+            }
+        }.contentShape(RoundedRectangle(
+            cornerRadius: 20,
+            style: .continuous
+        ))
+    }
+}

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/AvatarSummarized.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/AvatarSummarized.swift
@@ -7,7 +7,8 @@ extension EnkaHSR {
     public struct AvatarSummarized: Codable, Hashable {
         public let mainInfo: AvatarMainInfo
         public let equippedWeapon: WeaponPanel
-        public let avatarProperties: [PropertyPair]
+        public let avatarPropertiesA: [PropertyPair]
+        public let avatarPropertiesB: [PropertyPair]
         public let artifacts: [ArtifactInfo]
     }
 }
@@ -181,11 +182,16 @@ extension EnkaHSR.AvatarSummarized {
             self.localizedName = theDB.locTable[nameHash] ?? "EnkaId: \(fetched.tid)"
             self.trainedLevel = fetched.level
             self.refinement = fetched.rank
-            self.props = fetched.flat.props.compactMap { currentRecord in
+            self.basicProps = fetched.flat.props.compactMap { currentRecord in
                 if let theType = EnkaHSR.PropertyType(rawValue: currentRecord.type) {
                     return PropertyPair(theDB: theDB, type: theType, value: currentRecord.value)
                 }
                 return nil
+            }
+            self.specialProps = theDB.meta.equipmentSkill.query(
+                id: enkaId, stage: fetched.rank
+            ).map { key, value in
+                PropertyPair(theDB: theDB, type: key, value: value)
             }
         }
 
@@ -200,7 +206,8 @@ extension EnkaHSR.AvatarSummarized {
         public let localizedName: String
         public let trainedLevel: Int
         public let refinement: Int
-        public let props: [PropertyPair]
+        public let basicProps: [PropertyPair]
+        public let specialProps: [PropertyPair]
 
         public var rarityStars: Int { commonInfo.rarity }
 

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/AvatarSummarized.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/AvatarSummarized.swift
@@ -33,7 +33,7 @@ extension EnkaHSR.AvatarSummarized {
             self.element = theCommonInfo.element
             self.lifePath = theCommonInfo.avatarBaseType
             let charNameHash = theCommonInfo.avatarName.hash.description
-            self.localizedName = theDB.locTable[charNameHash] ?? charNameHash
+            self.localizedName = theDB.locTable[charNameHash] ?? "EnkaId: \(charId)"
         }
 
         // MARK: Public
@@ -177,7 +177,8 @@ extension EnkaHSR.AvatarSummarized {
             self.enkaId = fetched.tid
             self.commonInfo = theCommonInfo
             self.paramDataFetched = fetched
-            self.localizedName = theDB.locTable[fetched.tid.description] ?? "EnkaId: \(fetched.tid)"
+            let nameHash = theCommonInfo.equipmentName.hash.description
+            self.localizedName = theDB.locTable[nameHash] ?? "EnkaId: \(fetched.tid)"
             self.trainedLevel = fetched.level
             self.refinement = fetched.rank
             self.props = fetched.flat.props.compactMap { currentRecord in

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
@@ -24,17 +24,65 @@ extension EnkaHSR.QueryRelated.DetailInfo.Avatar {
             EnkaHSR.AvatarSummarized.ArtifactInfo(theDB: theDB, fetched: $0)
         }
 
-        // TODO: EnkaHSR requires manual calculation of avatar properties.
-        let testPair1 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .maxHP, value: 114)
-        let testPair2 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .defence, value: 514)
-        let testPair3 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .criticalDamage, value: 1.919)
-        let testPair4 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .criticalChance, value: 0.81)
+        // Panel: Add values from catched Metadata
+        let baseMeta = theDB.meta.avatar[avatarId.description]?[promotion.description]
+        guard let baseMeta = baseMeta else { return nil }
+        var panel = MutableAvatarPropertyPanel()
+        panel.maxHP = baseMeta.hpBase + baseMeta.hpAdd
+        panel.attack = baseMeta.attackBase + baseMeta.attackAdd
+        panel.defence = baseMeta.defenceBase + baseMeta.defenceAdd
+        panel.speed = baseMeta.speedBase
+        panel.criticalChance = baseMeta.criticalChance
+        panel.criticalDamage = baseMeta.criticalDamage
+        // TODO: 得请专人来检查这里的数值计算方法。此处还缺很多数据、还有很多算法是错的。
+
+        let propPair = panel.converted(theDB: theDB, element: mainInfo.element)
 
         return .init(
             mainInfo: mainInfo,
             equippedWeapon: equipInfo,
-            avatarProperties: [testPair1, testPair2, testPair3, testPair4],
+            avatarPropertiesA: propPair.0,
+            avatarPropertiesB: propPair.1,
             artifacts: artifactsInfo
         )
+    }
+}
+
+// MARK: - MutableAvatarPropertyPanel
+
+private struct MutableAvatarPropertyPanel {
+    public var maxHP: Double = 0
+    public var attack: Double = 0
+    public var defence: Double = 0
+    public var speed: Double = 0
+    public var criticalChance: Double = 0
+    public var criticalDamage: Double = 0
+    public var breakUp: Double = 0
+    public var energyRecovery: Double = 1
+    public var statusProbability: Double = 0
+    public var statusResistance: Double = 0
+    public var healRatio: Double = 0
+    public var elementalDMGAddedRatio: Double = 0
+
+    public func converted(
+        theDB: EnkaHSR.EnkaDB,
+        element: EnkaHSR
+            .Element
+    ) -> ([EnkaHSR.AvatarSummarized.PropertyPair], [EnkaHSR.AvatarSummarized.PropertyPair]) {
+        var resultA = [EnkaHSR.AvatarSummarized.PropertyPair]()
+        var resultB = [EnkaHSR.AvatarSummarized.PropertyPair]()
+        resultA.append(.init(theDB: theDB, type: .maxHP, value: maxHP))
+        resultA.append(.init(theDB: theDB, type: .attack, value: attack))
+        resultA.append(.init(theDB: theDB, type: .defence, value: defence))
+        resultA.append(.init(theDB: theDB, type: .speed, value: speed))
+        resultA.append(.init(theDB: theDB, type: .criticalChance, value: criticalChance))
+        resultA.append(.init(theDB: theDB, type: .criticalDamage, value: criticalDamage))
+        resultB.append(.init(theDB: theDB, type: .breakDamageAddedRatio, value: breakUp))
+        resultB.append(.init(theDB: theDB, type: .energyRecovery, value: energyRecovery))
+        resultB.append(.init(theDB: theDB, type: .statusProbability, value: statusProbability))
+        resultB.append(.init(theDB: theDB, type: .statusResistance, value: statusResistance))
+        resultB.append(.init(theDB: theDB, type: .healRatio, value: healRatio))
+        resultB.append(.init(theDB: theDB, type: element.damageAddedRatioProperty, value: elementalDMGAddedRatio))
+        return (resultA, resultB)
     }
 }

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
@@ -25,7 +25,16 @@ extension EnkaHSR.QueryRelated.DetailInfo.Avatar {
         }
 
         // TODO: EnkaHSR requires manual calculation of avatar properties.
+        let testPair1 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .maxHP, value: 114)
+        let testPair2 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .defence, value: 514)
+        let testPair3 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .criticalDamage, value: 1.919)
+        let testPair4 = EnkaHSR.AvatarSummarized.PropertyPair(theDB: theDB, type: .criticalChance, value: 0.81)
 
-        return .init(mainInfo: mainInfo, equippedWeapon: equipInfo, avatarProperties: [], artifacts: artifactsInfo)
+        return .init(
+            mainInfo: mainInfo,
+            equippedWeapon: equipInfo,
+            avatarProperties: [testPair1, testPair2, testPair3, testPair4],
+            artifacts: artifactsInfo
+        )
     }
 }

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
@@ -67,7 +67,8 @@ extension EnkaHSR.DBModels {
         case defenceAddedRatio = "DefenceAddedRatio"
         case defenceDelta = "DefenceDelta"
         case energyLimit = "EnergyLimit"
-        case energyRecovery = "EnergyRecovery"
+        case energyRecovery = "SPRatio"
+        case energyRecoveryBase = "SPRatioBase"
         case healRatio = "HealRatio"
         case healRatioBase = "HealRatioBase"
         case healTakenRatio = "HealTakenRatio"
@@ -78,8 +79,6 @@ extension EnkaHSR.DBModels {
         case speed = "Speed"
         case speedAddedRatio = "SpeedAddedRatio"
         case speedDelta = "SpeedDelta"
-        case spRatio = "SPRatio"
-        case spRatioBase = "SPRatioBase"
         case statusProbability = "StatusProbability"
         case statusProbabilityBase = "StatusProbabilityBase"
         case statusResistance = "StatusResistance"
@@ -101,6 +100,18 @@ extension EnkaHSR.DBModels.Element {
 
     public var iconFilePath: String {
         "\(EnkaHSR.assetPathRoot)/\(EnkaHSR.AssetPathComponents.element.rawValue)/\(iconFileName)"
+    }
+
+    public var damageAddedRatioProperty: EnkaHSR.PropertyType {
+        switch self {
+        case .physico: return .physicoAddedRatio
+        case .anemo: return .anemoAddedRatio
+        case .electro: return .electroAddedRatio
+        case .fantastico: return .fantasticoAddedRatio
+        case .posesto: return .posestoAddedRatio
+        case .pyro: return .pyroAddedRatio
+        case .cryo: return .cryoAddedRatio
+        }
     }
 }
 
@@ -145,7 +156,8 @@ extension EnkaHSR.PropertyType {
         case .criticalChanceBase: nameStem = "CriticalChance"
         case .statusProbabilityBase: nameStem = "StatusProbability"
         case .speedDelta: nameStem = "Speed"
-        case .spRatioBase: nameStem = "StatusProbability"
+        case .energyRecovery: nameStem = "EnergyRecovery"
+        case .energyRecoveryBase: nameStem = "EnergyRecovery"
         case .criticalDamageBase: nameStem = "CriticalDamage"
         default: break
         }
@@ -198,7 +210,7 @@ extension EnkaHSR.PropertyType {
         case .breakDamageAddedRatio: return true
         case .statusProbabilityBase: return true
         case .speedDelta: return true
-        case .spRatioBase: return true
+        case .energyRecoveryBase: return true
         case .criticalDamageBase: return true
 
         default:
@@ -207,5 +219,34 @@ extension EnkaHSR.PropertyType {
             let condition2 = rawValue.prefix(9) != "AllDamage"
             return condition1 && condition2
         }
+    }
+
+    public static func getAvatarProperties(
+        element: EnkaHSR.Element
+    ) -> [EnkaHSR.PropertyType] {
+        var results: [EnkaHSR.PropertyType] = [
+            .maxHP,
+            .attack,
+            .defence,
+            .speed,
+            .criticalChance,
+            .criticalDamage,
+            .breakUp,
+            .energyRecovery,
+            .statusProbability,
+            .statusResistance,
+            .healRatio,
+        ]
+        switch element {
+        case .physico: results.append(.physicoAddedRatio)
+        case .anemo: results.append(.anemoAddedRatio)
+        case .electro: results.append(.electroAddedRatio)
+        case .fantastico: results.append(.fantasticoAddedRatio)
+        case .posesto: results.append(.posestoAddedRatio)
+        case .pyro: results.append(.pyroAddedRatio)
+        case .cryo: results.append(.cryoAddedRatio)
+        }
+
+        return results
     }
 }

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
@@ -146,16 +146,13 @@ extension EnkaHSR.PropertyType {
     public var iconFileName: String? {
         var nameStem = rawValue
         switch self {
-        case .attackAddedRatio, .defenceAddedRatio, .speedAddedRatio:
-            nameStem = nameStem.replacingOccurrences(of: "AddedRatio", with: "")
-        case .hpAddedRatio: nameStem = "MaxHP"
+        case .baseHP, .hpAddedRatio, .hpDelta: nameStem = "MaxHP"
         case .breakDamageAddedRatio: nameStem = "BreakUp"
-        case .hpDelta: nameStem = "MaxHP"
-        case .defenceDelta: nameStem = "Defence"
-        case .attackDelta: nameStem = "Attack"
+        case .baseDefence, .defenceAddedRatio, .defenceDelta: nameStem = "Defence"
+        case .attackAddedRatio, .attackDelta, .baseAttack: nameStem = "Attack"
         case .criticalChanceBase: nameStem = "CriticalChance"
         case .statusProbabilityBase: nameStem = "StatusProbability"
-        case .speedDelta: nameStem = "Speed"
+        case .speedAddedRatio, .speedDelta: nameStem = "Speed"
         case .energyRecovery: nameStem = "EnergyRecovery"
         case .energyRecoveryBase: nameStem = "EnergyRecovery"
         case .criticalDamageBase: nameStem = "CriticalDamage"
@@ -172,6 +169,7 @@ extension EnkaHSR.PropertyType {
     public var hasPropIcon: Bool {
         switch self {
         case .allDamageTypeAddedRatio: return false // An exceptional case.
+        case .baseAttack, .baseDefence, .baseHP: return true
         case .attack: return true
         case .breakUp: return true
         case .criticalChance: return true

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Artifacts.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Artifacts.swift
@@ -7,7 +7,7 @@
 extension EnkaHSR.DBModels {
     public typealias ArtifactsDict = [String: Artifact]
 
-    public struct Artifact: Codable {
+    public struct Artifact: Codable, Hashable {
         // MARK: Public
 
         public let rarity: Int

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Character.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Character.swift
@@ -5,10 +5,10 @@
 extension EnkaHSR.DBModels {
     public typealias CharacterDict = [String: Character]
 
-    public struct Character: Codable {
+    public struct Character: Codable, Hashable {
         // MARK: Public
 
-        public struct AvatarFullName: Codable {
+        public struct AvatarFullName: Codable, Hashable {
             // MARK: Public
 
             public let hash: Int64
@@ -20,7 +20,7 @@ extension EnkaHSR.DBModels {
             }
         }
 
-        public struct AvatarName: Codable {
+        public struct AvatarName: Codable, Hashable {
             // MARK: Public
 
             public let hash: Int64

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Meta.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Meta.swift
@@ -3,7 +3,7 @@
 // This code is released under the GPL v3.0 License (SPDX-License-Identifier: GPL-3.0)
 
 extension EnkaHSR.DBModels {
-    public struct Meta: Codable {
+    public struct Meta: Codable, Hashable {
         public let avatar: RawAvatarMetaDict
         public let equipment: RawEquipmentMetaDict
         public let equipmentSkill: RawEquipSkillMetaDict
@@ -39,7 +39,7 @@ extension EnkaHSR.DBModels.Meta.NestedPropValueMap {
 extension EnkaHSR.DBModels.Meta {
     public typealias RawAvatarMetaDict = [String: [String: AvatarMeta]]
 
-    public struct AvatarMeta: Codable {
+    public struct AvatarMeta: Codable, Hashable {
         // MARK: Public
 
         public let hpBase: Double
@@ -75,7 +75,7 @@ extension EnkaHSR.DBModels.Meta {
 extension EnkaHSR.DBModels.Meta {
     public typealias RawEquipmentMetaDict = [String: [String: EquipmentMeta]]
 
-    public struct EquipmentMeta: Codable {
+    public struct EquipmentMeta: Codable, Hashable {
         // MARK: Public
 
         public let baseHP: Double
@@ -109,8 +109,8 @@ extension EnkaHSR.DBModels.Meta {
 // Relic = Artifact
 
 extension EnkaHSR.DBModels.Meta {
-    public struct RawRelicDB: Codable {
-        public struct MainAffix: Codable {
+    public struct RawRelicDB: Codable, Hashable {
+        public struct MainAffix: Codable, Hashable {
             enum CodingKeys: String, CodingKey {
                 case property = "Property"
                 case baseValue = "BaseValue"
@@ -122,7 +122,7 @@ extension EnkaHSR.DBModels.Meta {
             let levelAdd: Double
         }
 
-        public struct SubAffix: Codable {
+        public struct SubAffix: Codable, Hashable {
             enum CodingKeys: String, CodingKey {
                 case property = "Property"
                 case baseValue = "BaseValue"

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Meta.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Meta.swift
@@ -19,8 +19,8 @@ extension EnkaHSR.DBModels.Meta {
 }
 
 extension EnkaHSR.DBModels.Meta.NestedPropValueMap {
-    public func query(id: some StringProtocol) -> [EnkaHSR.DBModels.PropertyType: Double] {
-        let rawResult = self[id.description]?.first?.value.first?.value ?? [:]
+    public func query(id: some StringProtocol, stage: Int) -> [EnkaHSR.DBModels.PropertyType: Double] {
+        let rawResult = self[id.description]?[stage.description]?["props"] ?? [:]
         var results = [EnkaHSR.DBModels.PropertyType: Double]()
         for (key, value) in rawResult {
             guard let propKey = EnkaHSR.DBModels.PropertyType(rawValue: key) else { continue }
@@ -29,8 +29,8 @@ extension EnkaHSR.DBModels.Meta.NestedPropValueMap {
         return results
     }
 
-    public func query(id: Int) -> [EnkaHSR.DBModels.PropertyType: Double] {
-        query(id: id.description)
+    public func query(id: Int, stage: Int) -> [EnkaHSR.DBModels.PropertyType: Double] {
+        query(id: id.description, stage: stage)
     }
 }
 

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/ProfileAvatar.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/ProfileAvatar.swift
@@ -7,7 +7,7 @@
 extension EnkaHSR.DBModels {
     public typealias ProfileAvatarDict = [String: ProfileAvatar]
 
-    public struct ProfileAvatar: Codable {
+    public struct ProfileAvatar: Codable, Hashable {
         // MARK: Public
 
         public let icon: String

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/SkillRanks.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/SkillRanks.swift
@@ -5,7 +5,7 @@
 extension EnkaHSR.DBModels {
     public typealias SkillRanksDict = [String: SkillRank]
 
-    public struct SkillRank: Codable {
+    public struct SkillRank: Codable, Hashable {
         // MARK: Public
 
         public let iconPath: String

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/SkillTree.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/SkillTree.swift
@@ -7,7 +7,7 @@ extension EnkaHSR.DBModels {
 
     public typealias SkillTree = [String: [SkillInTree]]
 
-    public enum SkillInTree: Codable {
+    public enum SkillInTree: Codable, Hashable {
         case baseSkill(String)
         case extendedSkills([String])
 

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Skills.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Skills.swift
@@ -5,7 +5,7 @@
 extension EnkaHSR.DBModels {
     public typealias SkillsDict = [String: Skill]
 
-    public struct Skill: Codable {
+    public struct Skill: Codable, Hashable {
         // MARK: Public
 
         public let iconPath: String

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Weps.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/SubModels/Weps.swift
@@ -5,10 +5,10 @@
 extension EnkaHSR.DBModels {
     public typealias WeaponsDict = [String: Weapon]
 
-    public struct Weapon: Codable {
+    public struct Weapon: Codable, Hashable {
         // MARK: Public
 
-        public struct EquipmentName: Codable {
+        public struct EquipmentName: Codable, Hashable {
             // MARK: Public
 
             public let hash: Int

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/QueriedProfile.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/QueriedProfile.swift
@@ -5,7 +5,7 @@
 extension EnkaHSR.QueryRelated {
     // MARK: - QueriedProfile
 
-    public struct QueriedProfile: Codable {
+    public struct QueriedProfile: Codable, Hashable {
         public let detailInfo: DetailInfo?
         public let uid: String
         public let message: String?
@@ -13,7 +13,7 @@ extension EnkaHSR.QueryRelated {
 
     // MARK: - DetailInfo
 
-    public struct DetailInfo: Codable {
+    public struct DetailInfo: Codable, Hashable {
         public let platform, level, friendCount: Int
         public let signature: String
         public let recordInfo: RecordInfo
@@ -28,7 +28,7 @@ extension EnkaHSR.QueryRelated {
 extension EnkaHSR.QueryRelated.DetailInfo {
     // MARK: - Avatar
 
-    public struct Avatar: Codable {
+    public struct Avatar: Codable, Hashable {
         // MARK: Public
 
         public let level, avatarId: Int
@@ -57,7 +57,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
 
     // MARK: - Equipment
 
-    public struct Equipment: Codable {
+    public struct Equipment: Codable, Hashable {
         // MARK: Public
 
         public let rank, level, tid, promotion: Int
@@ -76,33 +76,33 @@ extension EnkaHSR.QueryRelated.DetailInfo {
 
     // MARK: - EquipmentFlat
 
-    public struct EquipmentFlat: Codable {
+    public struct EquipmentFlat: Codable, Hashable {
         public let props: [Prop]
         public let name: Int
     }
 
     // MARK: - Prop
 
-    public struct Prop: Codable {
+    public struct Prop: Codable, Hashable {
         public let type: String
         public let value: Double
     }
 
     // MARK: - ArtifactItem
 
-    public struct ArtifactItem: Codable {
+    public struct ArtifactItem: Codable, Hashable {
         // MARK: Public
 
         // MARK: - SubAffixList
 
-        public struct SubAffixItem: Codable {
+        public struct SubAffixItem: Codable, Hashable {
             public let affixId, cnt: Int
             public let step: Int?
         }
 
         // MARK: - ArtifactItem.Flat
 
-        public struct Flat: Codable {
+        public struct Flat: Codable, Hashable {
             public let props: [Prop]
             public let setName, setID: Int
         }
@@ -129,13 +129,13 @@ extension EnkaHSR.QueryRelated.DetailInfo {
 
     // MARK: - SkillTreeItem
 
-    public struct SkillTreeItem: Codable {
+    public struct SkillTreeItem: Codable, Hashable {
         public let pointId, level: Int
     }
 
     // MARK: - RecordInfo
 
-    public struct RecordInfo: Codable {
+    public struct RecordInfo: Codable, Hashable {
         public let maxRogueChallengeScore, achievementCount: Int
         public let challengeInfo: ChallengeInfo
         public let equipmentCount, avatarCount: Int
@@ -143,7 +143,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
 
     // MARK: - ChallengeInfo
 
-    public struct ChallengeInfo: Codable {
+    public struct ChallengeInfo: Codable, Hashable {
         public let scheduleGroupId: Int
     }
 }

--- a/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
+++ b/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
@@ -33,7 +33,7 @@ final class HBEnkaAPITests: XCTestCase {
     }
 
     func testDecodingQueriedResults() throws {
-        let filePath = testDataPath + "TestQueryResult.json"
+        let filePath = testDataPath + "TestQueryResultEnka.json"
         let dataURL = URL(fileURLWithPath: filePath)
         guard let jsonData = try? Data(contentsOf: dataURL) else {
             assertionFailure("!!! Cannot access Enka Query Result JSON data.")

--- a/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
+++ b/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
@@ -57,7 +57,7 @@ final class HBEnkaAPITests: XCTestCase {
         XCTAssertEqual(summarized.mainInfo.localizedName, "黃泉")
         XCTAssertEqual(summarized.mainInfo.constellation, 2)
         XCTAssertEqual(summarized.equippedWeapon.enkaId, 23024)
-        XCTAssertEqual(summarized.equippedWeapon.props[0].localizedTitle, "基礎生命值")
+        XCTAssertEqual(summarized.equippedWeapon.basicProps[0].localizedTitle, "基礎生命值")
         XCTAssertEqual(summarized.artifacts[0].enkaId, 61171)
         print(summarized.mainInfo.photoFilePath)
         XCTAssertTrue(FileManager.default.fileExists(atPath: summarized.mainInfo.photoFilePath))

--- a/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
+++ b/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
@@ -63,6 +63,20 @@ final class HBEnkaAPITests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: summarized.mainInfo.photoFilePath))
     }
 
+    func testAllPropertyIconFileAccess() throws {
+        let fileMgr = FileManager.default
+        EnkaHSR.PropertyType.allCases.filter(\.hasPropIcon).forEach { prop in
+            XCTAssertNotNil(prop.iconFilePath)
+            guard let iconPath = prop.iconFilePath else { return }
+            let exists = fileMgr.fileExists(atPath: iconPath)
+            if !exists {
+                print("\nPath: \(iconPath)")
+                XCTAssertTrue(exists)
+                print("\n")
+            }
+        }
+    }
+
     func testPrintAllCharacterNames() throws {
         guard let locTable = getBundledLocTable()?["zh-tw"], let charTable = getBundledCharTable() else { return }
         charTable.forEach { charId, character in

--- a/Packages/HBEnkaAPI/Tests/TestData/TestQueryResultEnka.json
+++ b/Packages/HBEnkaAPI/Tests/TestData/TestQueryResultEnka.json
@@ -15,7 +15,7 @@
     },
     "headIcon": 201212,
     "worldLevel": 6,
-    "nickname": "恃玫",
+    "nickname": "田所浩二",
     "uid": 114514810,
     "isDisplayAvatar": true,
     "avatarDetailList": [


### PR DESCRIPTION
这是穹披助手的角色面板实作的第三期工程，主要内容如下：

1. 所有已经实作过的 EnkaAPI Codable Struct 均实作了 Hashable 特性、且针对部分结构实作了 Identifiable 特性（方便用于 SwiftUI 的 ForEach）。

2. 角色面板**前端**全部施工完成。

![image](https://github.com/pizza-studio/HSRPizzaHelper/assets/3164826/9acbe7de-c484-4287-8b9c-5a8e29835f29)


待办事项（Enka HSR 相关资料没有 Enka Genshin 资料库那么丰盈）：

1. 后端对角色最终面板参数的计算过程尚未实作（需要相关的公式）。上图当中的面板数据是乱填的。（Enka Genshin 请求来的 JSON 查询结果会包含现成的计算好了的面板参数值，但 Enka HSR 请求来的 JSON 查询结果不包含这些内容。）
