### PR TITLE
EnkaAPI // Calculate avatar properties during summarization.

### DIFF
--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/EachAvatarStatView.swift
@@ -188,8 +188,8 @@ extension EnkaHSR.AvatarSummarized.AvatarMainInfo {
                             }
                             .clipShape(Circle())
                         }.frame(
-                            width: 18,
-                            height: 18
+                            width: fontSize * 0.95,
+                            height: fontSize * 0.95
                         )
                         .background {
                             Color.black.clipShape(Circle()).blurMaterialBackground().opacity(0.3)

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
@@ -31,25 +31,37 @@ extension EnkaHSR.QueryRelated.DetailInfo.Avatar {
         // TODO: 得请专人来检查这里的数值计算方法。此处还缺很多数据、还有很多算法是错的。
 
         // Panel: Add basic values from catched character Metadata.
-        let baseMeta = theDB.meta.avatar[avatarId.description]?[promotion.description]
-        guard let baseMeta = baseMeta else { return nil }
+        let baseMetaCharacter = theDB.meta.avatar[avatarId.description]?[promotion.description]
+        guard let baseMetaCharacter = baseMetaCharacter else { return nil }
         var panel = MutableAvatarPropertyPanel()
-        panel.maxHP = baseMeta.hpBase
-        panel.attack = baseMeta.attackBase
-        panel.defence = baseMeta.defenceBase
-        panel.maxHP += baseMeta.hpAdd * Double(level - 1)
-        panel.attack += baseMeta.attackAdd * Double(level - 1)
-        panel.defence += baseMeta.defenceAdd * Double(level - 1)
-        panel.speed = baseMeta.speedBase
-        panel.criticalChance = baseMeta.criticalChance
-        panel.criticalDamage = baseMeta.criticalDamage
+        panel.maxHP = baseMetaCharacter.hpBase
+        panel.attack = baseMetaCharacter.attackBase
+        panel.defence = baseMetaCharacter.defenceBase
+        panel.maxHP += baseMetaCharacter.hpAdd * Double(level - 1)
+        panel.attack += baseMetaCharacter.attackAdd * Double(level - 1)
+        panel.defence += baseMetaCharacter.defenceAdd * Double(level - 1)
+        panel.speed = baseMetaCharacter.speedBase
+        panel.criticalChance = baseMetaCharacter.criticalChance
+        panel.criticalDamage = baseMetaCharacter.criticalDamage
+
+        // Panel: 来自武器的基础面板加成（HP, ATK, DEF）。
+        // English: Base Props from the Weapon.
+
+        let baseMetaWeapon = theDB.meta.equipment[equipment.tid.description]?[equipment.promotion.description]
+        guard let baseMetaWeapon = baseMetaWeapon else { return nil }
+        panel.maxHP += baseMetaWeapon.baseHP
+        panel.attack += baseMetaWeapon.baseAttack
+        panel.defence += baseMetaWeapon.baseDefence
+        panel.maxHP += baseMetaWeapon.hpAdd * Double(equipInfo.trainedLevel - 1)
+        panel.attack += baseMetaWeapon.attackAdd * Double(equipInfo.trainedLevel - 1)
+        panel.defence += baseMetaWeapon.defenceAdd * Double(equipInfo.trainedLevel - 1)
 
         // Panel: Handle all additional props
 
-        // Panel: 来自武器的面板加成。
-        // English: Base and Additional Props from the Weapon.
+        // Panel: 来自武器的副面板加成。
+        // English: Additional Props from the Weapon.
 
-        let weaponProps: [EnkaHSR.AvatarSummarized.PropertyPair] = equipInfo.allProps
+        let weaponSpecialProps: [EnkaHSR.AvatarSummarized.PropertyPair] = equipInfo.specialProps
 
         // Panel: 来自天赋树的面板加成。
         // English: Base and Additional Props from the Skill Tree.
@@ -89,8 +101,8 @@ extension EnkaHSR.QueryRelated.DetailInfo.Avatar {
             }
             return resultPairs
         }()
-        let rarProps = skillTreeProps + weaponProps + artifactProps + artifactSetProps
-        panel.triageAndHandle(theDB: theDB, rarProps, element: mainInfo.element)
+        let allProps = skillTreeProps + weaponSpecialProps + artifactProps + artifactSetProps
+        panel.triageAndHandle(theDB: theDB, allProps, element: mainInfo.element)
 
         // Panel: 将最终面板转成输出物件要用到的格式。
 

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/AvatarSummarySupport/QueriedProfile_Summarizer.swift
@@ -195,7 +195,8 @@ private struct MutableAvatarPropertyPanel {
         case element.damageAddedRatioProperty: elementalDMGAddedRatio += prop.value
         case .attack, .attackDelta, .baseAttack: attack += prop.value
         case .attackAddedRatio: attack *= (1 + prop.value)
-        case .baseHP, .hpAddedRatio, .hpDelta, .maxHP: maxHP += prop.value
+        case .baseHP, .hpDelta, .maxHP: maxHP += prop.value
+        case .hpAddedRatio: maxHP *= (1 + prop.value)
         case .baseSpeed, .speed, .speedDelta: speed += prop.value
         case .speedAddedRatio: speed *= (1 + prop.value)
         case .criticalChance, .criticalChanceBase: criticalChance += prop.value
@@ -221,14 +222,15 @@ extension EnkaHSR.AvatarSummarized.PropertyPair {
         element: EnkaHSR.Element
     ) {
         switch type {
-        case .attackAddedRatio, .defenceAddedRatio, .speedAddedRatio: arrAmp.append(self)
+        case .attackAddedRatio, .defenceAddedRatio, .speedAddedRatio, .hpAddedRatio: arrAmp.append(self)
         case .attack, .attackDelta,
              .baseAttack, .baseDefence, .baseHP, .baseSpeed,
              .breakDamageAddedRatio, .breakDamageAddedRatioBase,
              .breakUp, .criticalChance, .criticalChanceBase,
              .criticalDamage, .criticalDamageBase, .defence,
-             .defenceDelta, element.damageAddedRatioProperty, .energyRecovery, .energyRecoveryBase,
-             .healRatio, .healRatioBase, .hpAddedRatio,
+             .defenceDelta, element.damageAddedRatioProperty,
+             .energyRecovery, .energyRecoveryBase,
+             .healRatio, .healRatioBase,
              .hpDelta, .maxHP, .speed,
              .speedDelta, .statusProbability,
              .statusProbabilityBase, .statusResistance,

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
@@ -150,6 +150,7 @@ extension EnkaHSR.PropertyType {
             || rawValue.contains("Ratio")
             || rawValue.contains("Crit")
             || rawValue.contains("StatusResistance")
+            || rawValue.contains("BreakUp")
     }
 
     public var iconFileName: String? {

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaDBModels/Enums.swift
@@ -149,8 +149,10 @@ extension EnkaHSR.PropertyType {
             || rawValue.contains("Probability")
             || rawValue.contains("Ratio")
             || rawValue.contains("Crit")
-            || rawValue.contains("StatusResistance")
+            || rawValue.contains("Rate")
+            || rawValue.contains("Resistance")
             || rawValue.contains("BreakUp")
+            || rawValue.contains("Damage")
     }
 
     public var iconFileName: String? {


### PR DESCRIPTION
The data handling part of the EnkaAPI Character ShowCase Support is almost completed.

This PR finishes all avatar properties' calculation, except MaxHP, DEF, and ATK.

![image](https://github.com/pizza-studio/HSRPizzaHelper/assets/3164826/6775e122-1e96-406f-8e74-2b8e5211990d)

The correct one:
![image](https://github.com/pizza-studio/HSRPizzaHelper/assets/3164826/6c99cca4-3156-44e9-8dee-f6caacadab32)

