### PR TITLE
EnkaAPI // Add MiHoMoAPI mirror server support.

### DIFF
--- a/Features/System/View/ThanksView.swift
+++ b/Features/System/View/ThanksView.swift
@@ -20,6 +20,7 @@ struct ThanksView: View {
                 Text(verbatim: "SwifterSwift\nhttps://github.com/SwifterSwift/SwifterSwift")
                 Text(verbatim: "Defaults - Sindre Sorhus\nhttps://github.com/sindresorhus/Defaults")
                 Text(verbatim: "Enka API - Enka Network\nhttps://enka.network/?hsr")
+                Text(verbatim: "MiHoMo Origin API Mirror - MiHoMo\nhttps://github.com/Mar-7th/March7th-Docs")
             }
             .font(.caption)
             Divider()

--- a/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/SwiftUIImpl/SwiftUIImpl_Pizza.swift
+++ b/Packages/HBEnkaAPI/Sources/EnkaSwiftUIViews/SwiftUIImpl/SwiftUIImpl_Pizza.swift
@@ -27,6 +27,17 @@ public struct ResIcon: View {
     public let imageHandler: (Image) -> Image
 
     public var body: some View {
+        #if os(OSX)
+        if let image = NSImage(contentsOfFile: path) {
+            imageHandler(Image(nsImage: image))
+        } else {
+            AsyncImage(url: .init(fileURLWithPath: path)) { image in
+                imageHandler(image)
+            } placeholder: {
+                placeholder()
+            }
+        }
+        #else
         if let image = UIImage(contentsOfFile: path) {
             imageHandler(Image(uiImage: image))
         } else {
@@ -36,6 +47,7 @@ public struct ResIcon: View {
                 placeholder()
             }
         }
+        #endif
     }
 }
 

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/DataSummarySupport/AvatarSummarized.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/DataSummarySupport/AvatarSummarized.swift
@@ -240,12 +240,12 @@ extension EnkaHSR.AvatarSummarized {
             self.localizedName = theDB.locTable[nameHash] ?? "EnkaId: \(fetched.tid)"
             self.trainedLevel = fetched.level
             self.refinement = fetched.rank
-            self.basicProps = fetched.flat.props.compactMap { currentRecord in
+            self.basicProps = fetched.flat?.props.compactMap { currentRecord in
                 if let theType = EnkaHSR.PropertyType(rawValue: currentRecord.type) {
                     return PropertyPair(theDB: theDB, type: theType, value: currentRecord.value)
                 }
                 return nil
-            }
+            } ?? []
             // TODO: 目前先忽略那些没有图标的词条，回头单独再订做一套图标。
             self.specialProps = theDB.meta.equipmentSkill.query(
                 id: enkaId, stage: fetched.rank
@@ -295,12 +295,12 @@ extension EnkaHSR.AvatarSummarized {
             self.enkaId = fetched.tid
             self.commonInfo = theCommonInfo
             self.paramDataFetched = fetched
-            let props: [PropertyPair] = fetched.flat.props.compactMap { currentRecord in
+            let props: [PropertyPair] = fetched.flat?.props.compactMap { currentRecord in
                 if let theType = EnkaHSR.PropertyType(rawValue: currentRecord.type) {
                     return PropertyPair(theDB: theDB, type: theType, value: currentRecord.value, isArtifact: true)
                 }
                 return nil
-            }
+            } ?? []
             guard let theMainProp = props.first else { return nil }
             self.mainProp = theMainProp
             self.subProps = Array(props.dropFirst())

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/DataSummarySupport/AvatarSummarized.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/DataSummarySupport/AvatarSummarized.swift
@@ -240,12 +240,12 @@ extension EnkaHSR.AvatarSummarized {
             self.localizedName = theDB.locTable[nameHash] ?? "EnkaId: \(fetched.tid)"
             self.trainedLevel = fetched.level
             self.refinement = fetched.rank
-            self.basicProps = fetched.flat?.props.compactMap { currentRecord in
+            self.basicProps = fetched.getFlat(theDB: theDB).props.compactMap { currentRecord in
                 if let theType = EnkaHSR.PropertyType(rawValue: currentRecord.type) {
                     return PropertyPair(theDB: theDB, type: theType, value: currentRecord.value)
                 }
                 return nil
-            } ?? []
+            }
             // TODO: 目前先忽略那些没有图标的词条，回头单独再订做一套图标。
             self.specialProps = theDB.meta.equipmentSkill.query(
                 id: enkaId, stage: fetched.rank
@@ -295,21 +295,25 @@ extension EnkaHSR.AvatarSummarized {
             self.enkaId = fetched.tid
             self.commonInfo = theCommonInfo
             self.paramDataFetched = fetched
-            let props: [PropertyPair] = fetched.flat?.props.compactMap { currentRecord in
+            guard let flat = fetched.getFlat(theDB: theDB) else { return nil }
+            let props: [PropertyPair] = flat.props.compactMap { currentRecord in
                 if let theType = EnkaHSR.PropertyType(rawValue: currentRecord.type) {
                     return PropertyPair(theDB: theDB, type: theType, value: currentRecord.value, isArtifact: true)
                 }
                 return nil
-            } ?? []
+            }
             guard let theMainProp = props.first else { return nil }
             self.mainProp = theMainProp
             self.subProps = Array(props.dropFirst())
+            self.setID = flat.setID
         }
 
         // MARK: Public
 
         /// Unique Artifact ID, defining its Rarity, Set Suite, and Body Part.
         public let enkaId: Int
+        /// Artifact Set ID.
+        public let setID: Int
         /// Common information fetched from EnkaDB.
         public let commonInfo: EnkaHSR.DBModels.Artifact
         /// Data from Enka query result profile.

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/DataSummarySupport/Implementations/QueriedProfile_Summarizer.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/DataSummarySupport/Implementations/QueriedProfile_Summarizer.swift
@@ -82,7 +82,7 @@ extension EnkaHSR.QueryRelated.DetailInfo.Avatar {
         let artifactSetProps: [EnkaHSR.AvatarSummarized.PropertyPair] = {
             var resultPairs = [EnkaHSR.AvatarSummarized.PropertyPair]()
             var setIDCounters: [Int: Int] = [:]
-            artifactsInfo.map(\.paramDataFetched.flat.setID).forEach { setIDCounters[$0, default: 0] += 1 }
+            artifactsInfo.compactMap(\.paramDataFetched.flat?.setID).forEach { setIDCounters[$0, default: 0] += 1 }
             setIDCounters.forEach { setId, count in
                 guard count >= 2 else { return }
                 let x = theDB.meta.relic.setSkill.query(id: setId, stage: 2).map {

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/ModelsAndImpls/QueriedProfile.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/ModelsAndImpls/QueriedProfile.swift
@@ -40,6 +40,7 @@ extension EnkaHSR.QueryRelated {
             self.isDisplayAvatar = isDisplayAvatar
             self.platform = platform
             self.avatarDetailList = avatarDetailList
+            self.assistAvatarList = []
         }
 
         public init(from decoder: Decoder) throws {
@@ -53,7 +54,13 @@ extension EnkaHSR.QueryRelated {
             self.headIcon = (try? container.decode(Int.self, forKey: .headIcon)) ?? 1310
             self.worldLevel = (try? container.decode(Int.self, forKey: .worldLevel)) ?? 0
             self.isDisplayAvatar = (try? container.decode(Bool.self, forKey: .isDisplayAvatar)) ?? false
-            self.avatarDetailList = (try? container.decode([Avatar].self, forKey: .avatarDetailList)) ?? []
+            // 在这个阶段就将 assistAvatarList 的内容并入到 avatarDetailList 内。
+            let avatarListPrimary = (try? container.decode([Avatar].self, forKey: .assistAvatarList)) ?? []
+            var avatarListSecondary = (try? container.decode([Avatar].self, forKey: .avatarDetailList)) ?? []
+            let filteredCharIDs = avatarListPrimary.map(\.avatarId)
+            avatarListSecondary.removeAll { filteredCharIDs.contains($0.avatarId) }
+            self.assistAvatarList = []
+            self.avatarDetailList = avatarListPrimary + avatarListSecondary
             do {
                 self.platform = .init(rawValue: (try container.decode(Int?.self, forKey: .platform)) ?? 0) ?? .editor
             } catch {
@@ -72,7 +79,7 @@ extension EnkaHSR.QueryRelated {
         public let isDisplayAvatar: Bool
         public let platform: PlatformType
         public let avatarDetailList: [Avatar]
-        // public let assistAvatarList: [Avatar]
+        public let assistAvatarList: [Avatar]
     }
 }
 

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/ModelsAndImpls/QueriedProfile.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/ModelsAndImpls/QueriedProfile.swift
@@ -7,7 +7,7 @@ extension EnkaHSR.QueryRelated {
 
     public struct QueriedProfile: Codable, Hashable {
         public let detailInfo: DetailInfo?
-        public let uid: String
+        public let uid: String?
         public let message: String?
     }
 
@@ -45,19 +45,19 @@ extension EnkaHSR.QueryRelated {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.uid = try container.decode(Int.self, forKey: .uid)
-            self.nickname = try container.decode(String?.self, forKey: .nickname) ?? "@Nanashibito"
-            self.level = try container.decode(Int?.self, forKey: .level) ?? 0
-            self.friendCount = try container.decode(Int?.self, forKey: .friendCount) ?? 0
-            self.signature = try container.decode(String?.self, forKey: .signature) ?? ""
-            self.recordInfo = try container.decode(RecordInfo?.self, forKey: .recordInfo)
-            self.headIcon = try container.decode(Int?.self, forKey: .headIcon) ?? 1310
-            self.worldLevel = try container.decode(Int?.self, forKey: .worldLevel) ?? 0
-            self.isDisplayAvatar = try container.decode(Bool?.self, forKey: .isDisplayAvatar) ?? false
-            self.avatarDetailList = try container.decode([Avatar]?.self, forKey: .avatarDetailList) ?? []
+            self.nickname = (try? container.decode(String.self, forKey: .nickname)) ?? "@Nanashibito"
+            self.level = (try? container.decode(Int.self, forKey: .level)) ?? 0
+            self.friendCount = (try? container.decode(Int.self, forKey: .friendCount)) ?? 0
+            self.signature = (try? container.decode(String.self, forKey: .signature)) ?? ""
+            self.recordInfo = try? container.decode(RecordInfo.self, forKey: .recordInfo)
+            self.headIcon = (try? container.decode(Int.self, forKey: .headIcon)) ?? 1310
+            self.worldLevel = (try? container.decode(Int.self, forKey: .worldLevel)) ?? 0
+            self.isDisplayAvatar = (try? container.decode(Bool.self, forKey: .isDisplayAvatar)) ?? false
+            self.avatarDetailList = (try? container.decode([Avatar].self, forKey: .avatarDetailList)) ?? []
             do {
-                self.platform = .init(rawValue: try container.decode(Int?.self, forKey: .platform) ?? 0) ?? .editor
+                self.platform = .init(rawValue: (try container.decode(Int?.self, forKey: .platform)) ?? 0) ?? .editor
             } catch {
-                self.platform = .init(string: try container.decode(String?.self, forKey: .platform) ?? "EDITOR")
+                self.platform = .init(string: (try? container.decode(String?.self, forKey: .platform)) ?? "EDITOR")
             }
         }
 
@@ -108,7 +108,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
 
         public let rank, level, tid: Int
         public let promotion: Int?
-        public let flat: EquipmentFlat
+        public let flat: EquipmentFlat?
 
         // Promotion, guarded
         public var promotionRank: Int {
@@ -163,7 +163,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
         public let level: Int?
         public let subAffixList: [SubAffixItem]
         public let mainAffixId, tid: Int
-        public let flat: ArtifactItem.Flat
+        public let flat: ArtifactItem.Flat?
         public let exp: Int?
 
         // MARK: Internal

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/ModelsAndImpls/QueriedProfile.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/ModelsAndImpls/QueriedProfile.swift
@@ -107,8 +107,8 @@ extension EnkaHSR.QueryRelated.DetailInfo {
         // MARK: Public
 
         public let rank, level, tid: Int
+        // public let flat: EquipmentFlat? // UNAVAILABLE_IN_MIHOMO_ORIGIN_RESULTS.
         public let promotion: Int?
-        public let flat: EquipmentFlat?
 
         // Promotion, guarded
         public var promotionRank: Int {
@@ -122,7 +122,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
             case level
             case tid
             case promotion
-            case flat = "_flat"
+            // case flat = "_flat" // UNAVAILABLE_IN_MIHOMO_ORIGIN_RESULTS.
         }
     }
 
@@ -163,7 +163,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
         public let level: Int?
         public let subAffixList: [SubAffixItem]
         public let mainAffixId, tid: Int
-        public let flat: ArtifactItem.Flat?
+        // public let flat: ArtifactItem.Flat? // UNAVAILABLE_IN_MIHOMO_ORIGIN_RESULTS.
         public let exp: Int?
 
         // MARK: Internal
@@ -174,7 +174,7 @@ extension EnkaHSR.QueryRelated.DetailInfo {
             case subAffixList
             case mainAffixId
             case tid
-            case flat = "_flat"
+            // case flat = "_flat" // UNAVAILABLE_IN_MIHOMO_ORIGIN_RESULTS.
             case exp
         }
     }

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/Sputnik/Sputnik.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/EnkaQueryRelated/Sputnik/Sputnik.swift
@@ -131,7 +131,8 @@ extension EnkaHSR.Sputnik {
             )
             throw EnkaHSR.QueryRelated.Exception.refreshTooFast(dateWhenRefreshable: date)
         } else {
-            let enkaOfficial = EnkaHSR.HostType.profileQueryURLHeader + uid
+            let server = EnkaHSR.HostType(uid: uid)
+            let enkaOfficial = server.profileQueryURLHeader + uid
             // swiftlint:disable force_unwrapping
             let url = URL(string: enkaOfficial)!
             // swiftlint:enable force_unwrapping

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/HBEnkaAPI.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/HBEnkaAPI.swift
@@ -119,12 +119,24 @@ extension EnkaHSR {
         case mainlandChina = 0
         case enkaGlobal = 1
 
-        // MARK: Public
+        // MARK: Lifecycle
 
-        public static var profileQueryURLHeader: String {
-            // MicroGG 目前不支持星穹铁道的资料查询。
-            "https://enka.network/api/hsr/uid/"
+        public init(uid: String) {
+            var theUID = uid
+            while theUID.count > 9 {
+                theUID = theUID.dropFirst().description
+            }
+            guard let initial = theUID.first, let initialInt = Int(initial.description) else {
+                self = .enkaGlobal
+                return
+            }
+            switch initialInt {
+            case 1 ... 5: self = .mainlandChina
+            default: self = .enkaGlobal
+            }
         }
+
+        // MARK: Public
 
         public var enkaDBSourceURLHeader: String {
             switch self {
@@ -134,7 +146,10 @@ extension EnkaHSR {
         }
 
         public var profileQueryURLHeader: String {
-            Self.profileQueryURLHeader
+            switch self {
+            case .mainlandChina: return "https://api.mihomo.me/sr_info/"
+            case .enkaGlobal: return "https://enka.network/api/hsr/uid/"
+            }
         }
 
         public func viceVersa() -> Self {

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/MiHoMoSupport/MiHoMoQueriedImpl/MiHoMoRequest.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/MiHoMoSupport/MiHoMoQueriedImpl/MiHoMoRequest.swift
@@ -1,0 +1,37 @@
+// (c) 2023 and onwards Pizza Studio (GPL v3.0 License).
+// ====================
+// This code is released under the GPL v3.0 License (SPDX-License-Identifier: GPL-3.0)
+
+import Foundation
+
+extension MiHoMo.QueriedProfile {
+    public static func fetch(lang: String = "en", uid: String) async throws -> Self {
+        let langTag = lang.isEmpty ? "" : "&lang=\(lang)"
+        let urlLink = "https://api.mihomo.me/sr_info_parsed/\(uid)?version=v2\(langTag)"
+        // swiftlint:disable force_unwrapping
+        let url = URL(string: urlLink)!
+        // swiftlint:enable force_unwrapping
+        let (data, _) = try await URLSession.shared.data(for: URLRequest(url: url))
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let requestResult = try decoder.decode(
+            Self.self,
+            from: data
+        )
+        return requestResult
+    }
+
+    public static func fetchEnka(uid: String) async throws -> EnkaHSR.QueryRelated.QueriedProfile {
+        let urlLink = "https://api.mihomo.me/sr_info/\(uid)"
+        // swiftlint:disable force_unwrapping
+        let url = URL(string: urlLink)!
+        // swiftlint:enable force_unwrapping
+        let (data, _) = try await URLSession.shared.data(for: URLRequest(url: url))
+        let decoder = JSONDecoder()
+        let requestResult = try decoder.decode(
+            EnkaHSR.QueryRelated.QueriedProfile.self,
+            from: data
+        )
+        return requestResult
+    }
+}

--- a/Packages/HBEnkaAPI/Sources/HBEnkaAPI/MiHoMoSupport/MiHoMoQueriedProfile.swift
+++ b/Packages/HBEnkaAPI/Sources/HBEnkaAPI/MiHoMoSupport/MiHoMoQueriedProfile.swift
@@ -1,0 +1,174 @@
+// (c) 2023 and onwards Pizza Studio (GPL v3.0 License).
+// ====================
+// This code is released under the GPL v3.0 License (SPDX-License-Identifier: GPL-3.0)
+
+// MARK: - MiHoMo
+
+public enum MiHoMo {
+    public struct QueriedProfile: Codable, Hashable {
+        public let player: PlayerInfo
+        public let characters: [CharacterInfo]
+    }
+}
+
+// MARK: - Structs
+
+extension MiHoMo.QueriedProfile {
+    public struct LevelInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let level: Int
+    }
+
+    public struct AvatarInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let icon: String
+    }
+
+    public struct PathInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let icon: String
+    }
+
+    public struct ElementInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let color: String
+        public let icon: String
+    }
+
+    public struct SkillInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let level: Int
+        public let maxLevel: Int
+        public let element: ElementInfo?
+        public let type: String
+        public let typeText: String
+        public let effect: String
+        public let effectText: String
+        public let simpleDesc: String
+        public let desc: String
+        public let icon: String
+    }
+
+    public struct SkillTreeInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let level: Int
+        public let anchor: String
+        public let maxLevel: Int
+        public let icon: String
+        public let parent: String?
+    }
+
+    public struct AttributeInfo: Codable, Hashable {
+        public let field: String
+        public let name: String
+        public let icon: String
+        public let value: Float
+        public let display: String
+        public let percent: Bool
+    }
+
+    public struct PropertyInfo: Codable, Hashable {
+        public let type: String
+        public let field: String
+        public let name: String
+        public let icon: String
+        public let value: Float
+        public let display: String
+        public let percent: Bool
+    }
+
+    public struct SubAffixInfo: Codable, Hashable {
+        public let count: Int
+        public let step: Int
+        public let type: String
+        public let field: String
+        public let name: String
+        public let icon: String
+        public let value: Float
+        public let display: String
+        public let percent: Bool
+    }
+
+    public struct RelicInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let setId: String
+        public let setName: String
+        public let rarity: Int
+        public let level: Int
+        public let icon: String
+        public let mainAffix: PropertyInfo?
+        public let subAffix: [SubAffixInfo]
+    }
+
+    public struct RelicSetInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let icon: String
+        public let num: Int
+        public let desc: String
+        public let properties: [PropertyInfo]
+    }
+
+    public struct LightConeInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let rarity: Int
+        public let rank: Int
+        public let level: Int
+        public let promotion: Int
+        public let icon: String
+        public let preview: String
+        public let portrait: String
+        public let path: PathInfo?
+        public let attributes: [AttributeInfo]
+        public let properties: [PropertyInfo]
+    }
+
+    public struct SpaceInfo: Codable, Hashable {
+        // public let memoryData: MemoryInfo // Deprecated.
+        public let universeLevel: Int
+        public let lightConeCount: Int
+        public let avatarCount: Int
+        public let achievementCount: Int
+    }
+
+    public struct PlayerInfo: Codable, Hashable {
+        public let uid: String
+        public let nickname: String
+        public let level: Int
+        public let worldLevel: Int
+        public let friendCount: Int
+        public let avatar: AvatarInfo?
+        public let signature: String
+        public let isDisplay: Bool
+        public let spaceInfo: SpaceInfo?
+    }
+
+    public struct CharacterInfo: Codable, Hashable, Identifiable {
+        public let id: String
+        public let name: String
+        public let rarity: Int
+        public let rank: Int
+        public let level: Int
+        public let promotion: Int
+        public let icon: String
+        public let preview: String
+        public let portrait: String
+        public let rankIcons: [String]
+        public let path: PathInfo?
+        public let element: ElementInfo?
+        public let skills: [SkillInfo]
+        public let skillTrees: [SkillTreeInfo]
+        public let lightCone: LightConeInfo?
+        public let relics: [RelicInfo]
+        public let relicSets: [RelicSetInfo]
+        public let attributes: [AttributeInfo]
+        public let additions: [AttributeInfo]
+        public let properties: [PropertyInfo]
+    }
+}

--- a/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
+++ b/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/HBEnkaAPITests.swift
@@ -43,7 +43,7 @@ final class HBEnkaAPITests: XCTestCase {
         var profile: EnkaHSR.QueryRelated.QueriedProfile?
         do {
             let obj = try JSONDecoder().decode(EnkaHSR.QueryRelated.QueriedProfile.self, from: jsonData)
-            uid = obj.uid
+            uid = obj.uid ?? obj.detailInfo?.uid.description ?? 114514810.description
             profile = obj
         } catch {
             throw (error)

--- a/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/MiHoMoAPITests.swift
+++ b/Packages/HBEnkaAPI/Tests/HBEnkaAPITests/MiHoMoAPITests.swift
@@ -1,0 +1,29 @@
+// (c) 2023 and onwards Pizza Studio (GPL v3.0 License).
+// ====================
+// This code is released under the GPL v3.0 License (SPDX-License-Identifier: GPL-3.0)
+
+import Defaults
+@testable import HBEnkaAPI
+import XCTest
+
+// MARK: - MiHoMoAPITests
+
+final class MiHoMoAPITests: XCTestCase {
+    func testFetchingMiHoMoProfile() async throws {
+        do {
+            let dbObj = try await MiHoMo.QueriedProfile.fetch(uid: "114514810")
+            print(dbObj.player.uid)
+        } catch {
+            throw (error)
+        }
+    }
+
+    func testFetchingEnkaProfile() async throws {
+        do {
+            let dbObj = try await MiHoMo.QueriedProfile.fetchEnka(uid: "114514810")
+            print(dbObj.detailInfo?.uid ?? 114_514)
+        } catch {
+            throw (error)
+        }
+    }
+}

--- a/Packages/HBMihoyoAPI/Sources/HBMihoyoAPI/Common/Models/Server.swift
+++ b/Packages/HBMihoyoAPI/Sources/HBMihoyoAPI/Common/Models/Server.swift
@@ -17,6 +17,25 @@ public enum Server: String, CaseIterable {
     case europe = "prod_official_eur"
     case asia = "prod_official_asia"
     case hongKongMacauTaiwan = "prod_official_cht"
+
+    // MARK: Lifecycle
+
+    public init?(uid: String?) {
+        guard var theUID = uid else { return nil }
+        while theUID.count > 9 {
+            theUID = theUID.dropFirst().description
+        }
+        guard let initial = theUID.first, let initialInt = Int(initial.description) else { return nil }
+        switch initialInt {
+        case 1 ... 4: self = .china
+        case 5: self = .bilibili
+        case 6: self = .unitedStates
+        case 7: self = .europe
+        case 8: self = .asia
+        case 9: self = .hongKongMacauTaiwan
+        default: return nil
+        }
+    }
 }
 
 extension Server {


### PR DESCRIPTION
EnkaAPI 会借由自己的境外伺服器自己计算武器与圣遗物面板参数。
国服资料到了这个海外伺服器之后计算完毕再传回国内，要走两遍国际网关。
这使得 EnkaAPI 在查询国服资料的时候出现了大量的时间延迟，已经明显影响到了面板的使用体验。

万幸的是，EnkaAPI 的查询结果的 JSON 结构是「MiHoMoAPI 的 ORIGIN 查询结果 JSON 结构」的超集。
这样一来，使用 MiHoMoAPI 作为分流查询服务器（专门用来查询国服 UID 的面板）就显得有必要了。
这个 PR 完成了对 MiHoMoAPI 的查询支持。

因为这样一来势必要在用户设备上单独计算武器与圣遗物面板的具体参数，
所以这个 PR 也完善了仅利用 EnkaDB 就地计算武器与圣遗物面板参数的方法。
特此感谢 Enka Networks 私下提供的算法技术支持。

----------------

EnkaAPI server is situated outside of Mainland China, calculating Weapon and Artifact parameters.

For all HSR game accounts hosted in Celestia and Irminsul servers, these account's Enka Showcase data runs through the cross-border internet gate twice, resulting in significant time delays.

Fortunately, EnkaAPI Query Result JSON structure is a superset of the one used in the MiHoMo Origin Query Result. However, this results in the needs of calculating Weapon and Artifact parameters on users' device instead.

This PR allows the HBEnkaAPI Swift Package to treat MiHoMo as a mirror server, plus offline calculation of Weapon and Artifact parameters on the users' devices instead. Special thanks to Enka Networks for their help regarding the calculation methods.