### PR TITLE
Gacha // Keep the server gacha record timestamp intact.

### DIFF
--- a/Common/Model/CoreData/HSRPizzaHelper.xcdatamodeld/HSRPizzaHelper.xcdatamodel/contents
+++ b/Common/Model/CoreData/HSRPizzaHelper.xcdatamodeld/HSRPizzaHelper.xcdatamodel/contents
@@ -21,6 +21,7 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="rankRawValue" optional="YES" attributeType="String"/>
         <attribute name="time" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="timeRawValue" optional="YES" attributeType="String"/>
         <attribute name="uid" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/Features/Gacha/Model/GachaItemMO+CoreDataClass.swift
+++ b/Features/Gacha/Model/GachaItemMO+CoreDataClass.swift
@@ -24,6 +24,7 @@ extension GachaEntry {
         result.name = name
         result.rankRawValue = rankRawValue
         result.time = time
+        result.timeRawValue = timeRawValue
         result.uid = uid
         return result
     }
@@ -40,6 +41,7 @@ extension GachaEntry {
         result.name = name
         result.rankRawValue = rankRawValue
         result.time = time
+        result.timeRawValue = timeRawValue
         result.uid = uid
         return result
     }
@@ -58,6 +60,7 @@ extension GachaItemMO {
             name: name,
             rankRawValue: rankRawValue,
             time: time,
+            timeRawValue: timeRawValue,
             uid: uid
         )
     }

--- a/Features/Gacha/Model/GachaItemMO+CoreDataProperties.swift
+++ b/Features/Gacha/Model/GachaItemMO+CoreDataProperties.swift
@@ -28,6 +28,7 @@ extension GachaItemMO {
     @NSManaged public var name: String!
     @NSManaged public var rankRawValue: String!
     @NSManaged public var time: Date!
+    @NSManaged public var timeRawValue: String?
     @NSManaged public var uid: String!
 
     var gachaType: GachaType {

--- a/Features/Gacha/View/GetGacha/GetGachaViewModel.swift
+++ b/Features/Gacha/View/GetGacha/GetGachaViewModel.swift
@@ -168,6 +168,7 @@ class GetGachaViewModel: ObservableObject {
             persistedItem.name = gachaItem.name
             persistedItem.rank = gachaItem.rank
             persistedItem.time = gachaItem.time
+            persistedItem.timeRawValue = gachaItem.timeRawValue
             persistedItem.uid = gachaItem.uid
             withAnimation {
                 savedTypeFetchedCount[gachaItem.gachaType]! += 1

--- a/Packages/HBMihoyoAPI/Sources/HBMihoyoAPI/GachaAPI/GachaModel.swift
+++ b/Packages/HBMihoyoAPI/Sources/HBMihoyoAPI/GachaAPI/GachaModel.swift
@@ -92,13 +92,13 @@ public struct GachaItem: Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.uid = try container.decode(String.self, forKey: .uid)
-        let timeString = try container.decode(String.self, forKey: .time)
+        self.timeRawValue = try container.decode(String.self, forKey: .time)
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         // 抽卡记录的网页固定显示伺服器时间。
         dateFormatter.timeZone = .init(secondsFromGMT: Self.getServerTimeZoneDelta(uid) * 3600)
-        if let time = dateFormatter.date(from: timeString) {
+        if let time = dateFormatter.date(from: timeRawValue) {
             self.time = time
         } else {
             throw DecodingError.typeMismatch(
@@ -159,6 +159,7 @@ public struct GachaItem: Codable {
 
     public let uid: String
     public let time: Date
+    public let timeRawValue: String
     public let gachaID: String
     public let gachaType: GachaType
     public let itemID: String

--- a/Packages/SRGFKit/Sources/SRGFKit/GachaEntry.swift
+++ b/Packages/SRGFKit/Sources/SRGFKit/GachaEntry.swift
@@ -22,6 +22,7 @@ public struct GachaEntry: Codable, Sendable, Hashable, Identifiable {
         name: String,
         rankRawValue: String,
         time: Date,
+        timeRawValue: String?,
         uid: String
     ) {
         self.count = count
@@ -34,6 +35,7 @@ public struct GachaEntry: Codable, Sendable, Hashable, Identifiable {
         self.name = name
         self.rankRawValue = rankRawValue
         self.time = time
+        self.timeRawValue = timeRawValue
         self.uid = uid
     }
 
@@ -49,5 +51,6 @@ public struct GachaEntry: Codable, Sendable, Hashable, Identifiable {
     public var name: String
     public var rankRawValue: String
     public var time: Date
+    public var timeRawValue: String?
     public var uid: String
 }

--- a/Packages/SRGFKit/Sources/SRGFKit/SRGFv1.swift
+++ b/Packages/SRGFKit/Sources/SRGFKit/SRGFv1.swift
@@ -202,7 +202,7 @@ extension SRGFv1.DataEntry {
                 langOverride: lang
             ) ?? name
         }
-
+        let timeTyped: Date? = DateFormatter.forSRGFEntry(timeZoneDelta: timeZoneDelta).date(from: time)
         return .init(
             count: Int32(count ?? "1") ?? 1, // Default is 1.
             gachaID: gachaID,
@@ -213,7 +213,8 @@ extension SRGFv1.DataEntry {
             langRawValue: lang.rawValue,
             name: name ?? "#NAME:\(id)#",
             rankRawValue: rankType ?? "3",
-            time: DateFormatter.forSRGFEntry(timeZoneDelta: timeZoneDelta).date(from: time) ?? Date(),
+            time: timeTyped ?? Date(),
+            timeRawValue: time,
             uid: uid
         )
     }
@@ -233,7 +234,7 @@ extension GachaEntry {
         return .init(
             gachaID: gachaID,
             itemID: itemID,
-            time: time.asSRGFDate(timeZoneDelta: timeZoneDelta),
+            time: timeRawValue ?? time.asSRGFDate(timeZoneDelta: timeZoneDelta),
             id: id,
             gachaType: .init(rawValue: gachaTypeRawValue) ?? .departureWarp,
             name: name,


### PR DESCRIPTION
经 UIGF 群内有人实测发现：

1. 抽卡记录在抓取的时候显示的时间的所属时区永远都是伺服器所在的时区。
2. 天空岛、世界树、亚洲、港澳台伺服器的时区都是 UTC+8，美服 UTC-5，欧服 UTC+1。

穹披助手之前没有对抓取到的 Date String 原样备案的机制，
所以目前已知一个不可逆的资料错误（截至 v1.3.2 Beta 6 Build 417）：
**只要是之前用穹披助手抽取过的资料、且抓取时的设备时区与伺服器时区不一致的话，
那么抓到的每一笔抽卡资料都有时区偏移误差。**

穹披助手 v1.3.2 RC1 Build 423 修复了时区 Bug。
然而，为了根除今后产生这种误差的任何可能性，这个 PR 将带来下述改变：

1. CoreData 的 GachaItemMO 新增 Nullable 段位「timeRawValue」，用来存取原始 Date String。
2. 网页抓取抽卡记录资料时，将获得的 Date String 原样塞到「timeRawValue」内。
3. 汇入 SRGFv1 资料时，将获得的 SRGFv1.Entry().time 字串值也原样对接到 GachaItemMO 的「timeRawValue」上。
4. 汇出 SRGFv1 资料时，优先从「timeRawValue」获取资料值、对接到 SRGFv1.Entry().time 上。

该 PR 的审核点：

请务必重点检查任何「将 HBMihoyoAPI.GachaItem 转储成 GachaItemMO 且塞到 CoreData 资料库内」的场合、
看看有没有我忘记将 timeRawValue 存档的场合。